### PR TITLE
Allow the user to remove default control(s)

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -72,7 +72,12 @@ const extendingControls = function(moreControlObject) {
 
         // duplicated => error
         if (CONTROLS.hasOwnProperty(key)) {
-            throw new TypeError(`Extend-Control-Error: Your '${key}' control is duplicated with our build-in Controls. Please change to another key name instead.`);
+            if(moreControlObject[key] === false){
+                delete CONTROLS[key]
+                delete moreControlObject[key]
+            }else {
+                throw new TypeError(`Extend-Control-Error: Your '${key}' control is duplicated with our build-in Controls. Please change to another key name instead.`);
+            }
         }
     }
 

--- a/src/installer.js
+++ b/src/installer.js
@@ -73,9 +73,9 @@ const extendingControls = function(moreControlObject) {
         // duplicated => error
         if (CONTROLS.hasOwnProperty(key)) {
             if(moreControlObject[key] === false){
-                delete CONTROLS[key]
-                delete moreControlObject[key]
-            }else {
+                delete CONTROLS[key];
+                delete moreControlObject[key];
+            } else {
                 throw new TypeError(`Extend-Control-Error: Your '${key}' control is duplicated with our build-in Controls. Please change to another key name instead.`);
             }
         }


### PR DESCRIPTION
You can now disable a control during the `install`

```js
// Example: Remove the number and dropDown controls
Vue.use(VueFormBuilderPlugin, {
  controls: {
    number:   false,
    dropDown: false,
  }
})
```

Fix #85 