### PR TITLE
Fix #113: Impossible to turn off validation error alert

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -52,9 +52,8 @@ const VueFormBuilderInstaller = function(
     }
 
     // show alert or not?
-    formDI.validationErrorShowAlert = typeof properties.validationErrorShowAlert !== 'undefined'
-        ? Boolean(properties.validationErrorShowAlert)
-        : true
+    formDI.validationErrorShowAlert = typeof properties.validationErrorShowAlert !== 'undefined' ?
+        Boolean(properties.validationErrorShowAlert) : true;
     formDI.validationErrorAlertText = properties.validationErrorAlertText
 
     // disable control?

--- a/src/installer.js
+++ b/src/installer.js
@@ -52,7 +52,9 @@ const VueFormBuilderInstaller = function(
     }
 
     // show alert or not?
-    formDI.validationErrorShowAlert = properties.validationErrorShowAlert || true
+    formDI.validationErrorShowAlert = typeof properties.validationErrorShowAlert !== 'undefined'
+        ? Boolean(properties.validationErrorShowAlert)
+        : true
     formDI.validationErrorAlertText = properties.validationErrorAlertText
 
     // disable control?


### PR DESCRIPTION
Issue #113 stems from a faulty assignment in the plugin installer:

```js
    // show alert or not?
    formDI.validationErrorShowAlert = properties.validationErrorShowAlert || true
```

This will *always* default to `true` value in case `properties.validationErrorShowAlert` is "falsy".

We can fix this by checking if the option was defined first, and assign the default only if it wasn't.

```diff
     // show alert or not?
-    formDI.validationErrorShowAlert = properties.validationErrorShowAlert || true
+    formDI.validationErrorShowAlert = typeof properties.validationErrorShowAlert !== 'undefined'
+        ? Boolean(properties.validationErrorShowAlert)
+        : true
```