### PR TITLE
Fix #115: Custom validation closure does not exist and is bypassed

### DIFF
--- a/src/libraries/validation.js
+++ b/src/libraries/validation.js
@@ -26,7 +26,7 @@ export default class Validation {
      */
     constructor(valueContainer, controls, definedClosures = {}) {
         this.valueContainer = valueContainer
-        this.validationClosures = definedClosures
+        this.customClosures = definedClosures
         this.setRules(controls)
     }
 


### PR DESCRIPTION
It looks like the instance property responsible for collection of custom closures in the `Validation` class is not properly initialized.

The `customClosures` property defaults to an empty object `{}` that is never populated in the constructor.

On the other hand, an erroneous `validationClosures` property is initialized, but is never read from.

The fix is to initialize `customClosures` object properly, and custom validators will suddenly start working:

```diff
     constructor(valueContainer, controls, definedClosures = {}) {
         this.valueContainer = valueContainer
-        this.validationClosures = definedClosures
+        this.customClosures = definedClosures
         this.setRules(controls)
     }
```